### PR TITLE
Update analog.c

### DIFF
--- a/teensy3/analog.c
+++ b/teensy3/analog.c
@@ -524,8 +524,7 @@ void analogWriteDAC0(int val)
 	} else {
 		DAC0_C0 = DAC_C0_DACEN | DAC_C0_DACRFS; // 3.3V VDDA is DACREF_2
 	}
-	if (val < 0) val = 0;  // TODO: saturate instruction?
-	else if (val > 4095) val = 4095;
+	__asm__ ("usat    %[value], #12, %[value]\n\t" : [value] "+r" (val));
 
 	*(volatile aliased_int16_t *)&(DAC0_DAT0L) = val;
 #elif defined(__MKL26Z64__)
@@ -537,8 +536,7 @@ void analogWriteDAC0(int val)
 		// use whatever voltage is on the AREF pin
 		DAC0_C0 = DAC_C0_DACEN | DAC_C0_DACSWTRG; // 3.3V VDDA
 	}
-	if (val < 0) val = 0;
-	else if (val > 4095) val = 4095;
+	__asm__ ("usat    %[value], #12, %[value]\n\t" : [value] "+r" (val));
 
 	*(volatile aliased_int16_t *)&(DAC0_DAT0L) = val;
 #endif
@@ -554,8 +552,7 @@ void analogWriteDAC1(int val)
 	} else {
 		DAC1_C0 = DAC_C0_DACEN | DAC_C0_DACRFS; // 3.3V VDDA is DACREF_2
 	}
-	if (val < 0) val = 0;  // TODO: saturate instruction?
-	else if (val > 4095) val = 4095;
+	__asm__ ("usat    %[value], #12, %[value]\n\t" : [value] "+r" (val));
 
 	*(volatile aliased_int16_t *)&(DAC1_DAT0L) = val;
 }


### PR DESCRIPTION
Use ARM's unsigned saturate instruction to limit the value, to be written to DAC, to 11 bits (range 0 to 4095).